### PR TITLE
Fix missing defaultdict import

### DIFF
--- a/dual-subtitle-burner.py
+++ b/dual-subtitle-burner.py
@@ -5,7 +5,7 @@ import json
 import re
 import logging
 from pathlib import Path
-from collections import Counter
+from collections import Counter, defaultdict
 from collections import namedtuple
 
 try:


### PR DESCRIPTION
## Summary
- import defaultdict in main script to avoid NameError in subtitle normalization

## Testing
- `python -m py_compile dual-subtitle-burner.py sub-merger.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b89a2f7c8332a0118df09268ca9d