### PR TITLE
Refine positional subtitle handling

### DIFF
--- a/dual-subtitle-burner.py
+++ b/dual-subtitle-burner.py
@@ -5,7 +5,7 @@ import json
 import re
 import logging
 from pathlib import Path
-from collections import Counter
+from collections import Counter, defaultdict
 from collections import namedtuple
 
 try:
@@ -162,6 +162,67 @@ class SubMerger:
         )
 
     @staticmethod
+    def _has_explicit_positioning(s: str) -> bool:
+        return bool(
+            re.search(r"\{\\(?:pos|move|org|an\d)\b.*?\}", s, flags=re.IGNORECASE)
+        )
+
+    @staticmethod
+    def _force_vertical_region(text: str, to_top: bool) -> str:
+        def fix_an(match):
+            n = int(match.group(1))
+            if to_top:
+                if n <= 3:
+                    n += 6
+                elif n <= 6:
+                    n += 3
+            else:
+                if n >= 7:
+                    n -= 6
+                elif n >= 4:
+                    n -= 3
+            return f"\\an{n}"
+
+        def fix_pos(match):
+            parts = [p.strip() for p in match.group(1).split(",")]
+            x, y = map(int, parts[:2])
+            if to_top and y > 540:
+                y -= 540
+            elif not to_top and y < 540:
+                y += 540
+            return f"\\pos({x},{y})"
+
+        def fix_move(match):
+            parts = [p.strip() for p in match.group(1).split(",")]
+            x1, y1, x2, y2 = map(int, parts[:4])
+            if to_top:
+                if y1 > 540:
+                    y1 -= 540
+                if y2 > 540:
+                    y2 -= 540
+            else:
+                if y1 < 540:
+                    y1 += 540
+                if y2 < 540:
+                    y2 += 540
+            rest = parts[4:]
+            coords = [str(x1), str(y1), str(x2), str(y2), *rest]
+            return "\\move(" + ",".join(coords) + ")"
+
+        text = re.sub(r"\\an(\d)", fix_an, text)
+        text = re.sub(r"\\pos\(([^)]+)\)", fix_pos, text)
+        text = re.sub(r"\\move\(([^)]+)\)", fix_move, text)
+        return text
+
+    @staticmethod
+    def _ensure_top_position(text: str) -> str:
+        return SubMerger._force_vertical_region(text, True)
+
+    @staticmethod
+    def _ensure_bottom_position(text: str) -> str:
+        return SubMerger._force_vertical_region(text, False)
+
+    @staticmethod
     def _collect_change_points(events, style_filter):
         points = set()
         for line in events:
@@ -212,9 +273,7 @@ class SubMerger:
         secondary_points = SubMerger._collect_change_points(ev1, is_secondary)
         ev2 = SubMerger._split_events_on_points(ev1, secondary_points, is_primary)
 
-        tag_stripper = re.compile(
-            r"\{\\[^\}]*?(?:an|pos|move|org)[^\}]*\}", re.IGNORECASE
-        )
+        org_stripper = re.compile(r"\{\\[^\}]*?org[^\}]*\}", re.IGNORECASE)
         buckets = defaultdict(list)
         order = []
         for line in ev2:
@@ -238,6 +297,9 @@ class SubMerger:
             primaries, secondaries, others = [], [], []
             for p in buckets[key]:
                 st = p[3].strip()
+                if SubMerger._has_explicit_positioning(p[9]):
+                    others.append(p)
+                    continue
                 mapped = style_map.get(st)
                 if mapped == "Top-Primary":
                     primaries.append(p)
@@ -260,10 +322,14 @@ class SubMerger:
 
             for p in keep + others:
                 st = p[3].strip()
-                mapped = style_map.get(st, st)
-                p[3] = mapped
-                p[9] = tag_stripper.sub("", p[9])
-                normalized.append(",".join(p))
+                if SubMerger._has_explicit_positioning(p[9]):
+                    p[9] = org_stripper.sub("", SubMerger._ensure_top_position(p[9]))
+                    normalized.append(",".join(p))
+                else:
+                    mapped = style_map.get(st, st)
+                    p[3] = mapped
+                    p[9] = org_stripper.sub("", SubMerger._ensure_top_position(p[9]))
+                    normalized.append(",".join(p))
         return normalized
 
     # ----------------------------- Bottom (Chinese) pipeline -----------------------------
@@ -281,11 +347,6 @@ class SubMerger:
             "sign",
             "sfx",
         }
-
-        def has_explicit_positioning(s: str) -> bool:
-            return bool(
-                re.search(r"\{\\(?:pos|move|org|an\d)\b.*?\}", s, flags=re.IGNORECASE)
-            )
 
         def is_karaoke_or_template(effect: str, text: str) -> bool:
             return (
@@ -315,13 +376,24 @@ class SubMerger:
             effect = p[8]
             text = p[9]
 
+            has_pos = SubMerger._has_explicit_positioning(text)
             if (
                 st.casefold() in passthrough_styles
-                or has_explicit_positioning(text)
                 or is_karaoke_or_template(effect, text)
                 or st.casefold() not in processable
             ):
-                final_events.append(line)
+                if has_pos:
+                    p[9] = SubMerger._ensure_bottom_position(text)
+                    final_events.append(",".join(p))
+                else:
+                    final_events.append(line)
+                if st in styles2:
+                    kept_styles.add(st)
+                continue
+
+            if has_pos:
+                p[9] = SubMerger._ensure_bottom_position(text)
+                final_events.append(",".join(p))
                 if st in styles2:
                     kept_styles.add(st)
                 continue

--- a/sub-merger.py
+++ b/sub-merger.py
@@ -107,6 +107,67 @@ class SubMerger:
         )
 
     @staticmethod
+    def _has_explicit_positioning(s: str) -> bool:
+        return bool(
+            re.search(r"\{\\(?:pos|move|org|an\d)\b.*?\}", s, flags=re.IGNORECASE)
+        )
+
+    @staticmethod
+    def _force_vertical_region(text: str, to_top: bool) -> str:
+        def fix_an(match):
+            n = int(match.group(1))
+            if to_top:
+                if n <= 3:
+                    n += 6
+                elif n <= 6:
+                    n += 3
+            else:
+                if n >= 7:
+                    n -= 6
+                elif n >= 4:
+                    n -= 3
+            return f"\\an{n}"
+
+        def fix_pos(match):
+            parts = [p.strip() for p in match.group(1).split(",")]
+            x, y = map(int, parts[:2])
+            if to_top and y > 540:
+                y -= 540
+            elif not to_top and y < 540:
+                y += 540
+            return f"\\pos({x},{y})"
+
+        def fix_move(match):
+            parts = [p.strip() for p in match.group(1).split(",")]
+            x1, y1, x2, y2 = map(int, parts[:4])
+            if to_top:
+                if y1 > 540:
+                    y1 -= 540
+                if y2 > 540:
+                    y2 -= 540
+            else:
+                if y1 < 540:
+                    y1 += 540
+                if y2 < 540:
+                    y2 += 540
+            rest = parts[4:]
+            coords = [str(x1), str(y1), str(x2), str(y2), *rest]
+            return "\\move(" + ",".join(coords) + ")"
+
+        text = re.sub(r"\\an(\d)", fix_an, text)
+        text = re.sub(r"\\pos\(([^)]+)\)", fix_pos, text)
+        text = re.sub(r"\\move\(([^)]+)\)", fix_move, text)
+        return text
+
+    @staticmethod
+    def _ensure_top_position(text: str) -> str:
+        return SubMerger._force_vertical_region(text, True)
+
+    @staticmethod
+    def _ensure_bottom_position(text: str) -> str:
+        return SubMerger._force_vertical_region(text, False)
+
+    @staticmethod
     def _collect_change_points(events, style_filter):
         points = set()
         for line in events:
@@ -157,9 +218,7 @@ class SubMerger:
         secondary_points = SubMerger._collect_change_points(ev1, is_secondary)
         ev2 = SubMerger._split_events_on_points(ev1, secondary_points, is_primary)
 
-        tag_stripper = re.compile(
-            r"\{\\[^\}]*?(?:an|pos|move|org)[^\}]*\}", re.IGNORECASE
-        )
+        org_stripper = re.compile(r"\{\\[^\}]*?org[^\}]*\}", re.IGNORECASE)
         buckets = defaultdict(list)
         order = []
         for line in ev2:
@@ -184,6 +243,9 @@ class SubMerger:
             primaries, secondaries, others = [], [], []
             for p in buckets[key]:
                 st = p[3].strip()
+                if SubMerger._has_explicit_positioning(p[9]):
+                    others.append(p)
+                    continue
                 mapped = style_map.get(st)
                 if mapped == "Top-Primary":
                     primaries.append(p)
@@ -206,10 +268,14 @@ class SubMerger:
 
             for p in keep + others:
                 st = p[3].strip()
-                mapped = style_map.get(st, st)
-                p[3] = mapped
-                p[9] = tag_stripper.sub("", p[9])
-                normalized.append(",".join(p))
+                if SubMerger._has_explicit_positioning(p[9]):
+                    p[9] = org_stripper.sub("", SubMerger._ensure_top_position(p[9]))
+                    normalized.append(",".join(p))
+                else:
+                    mapped = style_map.get(st, st)
+                    p[3] = mapped
+                    p[9] = org_stripper.sub("", SubMerger._ensure_top_position(p[9]))
+                    normalized.append(",".join(p))
         return normalized
 
     # ----------------------------- Bottom (Chinese) pipeline -----------------------------
@@ -227,11 +293,6 @@ class SubMerger:
             "sign",
             "sfx",
         }
-
-        def has_explicit_positioning(s: str) -> bool:
-            return bool(
-                re.search(r"\{\\(?:pos|move|org|an\d)\b.*?\}", s, flags=re.IGNORECASE)
-            )
 
         def is_karaoke_or_template(effect: str, text: str) -> bool:
             return (
@@ -261,13 +322,24 @@ class SubMerger:
             effect = p[8]
             text = p[9]
 
+            has_pos = SubMerger._has_explicit_positioning(text)
             if (
                 st.casefold() in passthrough_styles
-                or has_explicit_positioning(text)
                 or is_karaoke_or_template(effect, text)
                 or st.casefold() not in processable
             ):
-                final_events.append(line)
+                if has_pos:
+                    p[9] = SubMerger._ensure_bottom_position(text)
+                    final_events.append(",".join(p))
+                else:
+                    final_events.append(line)
+                if st in styles2:
+                    kept_styles.add(st)
+                continue
+
+            if has_pos:
+                p[9] = SubMerger._ensure_bottom_position(text)
+                final_events.append(",".join(p))
                 if st in styles2:
                     kept_styles.add(st)
                 continue


### PR DESCRIPTION
## Summary
- add helpers to detect and relocate positioned subtitles so English stays on top and Chinese at bottom
- normalize English events without stripping positional tags while preserving style for explicitly placed lines
- sanitize Chinese subtitles, shifting any explicitly positioned lines away from the English region

## Testing
- `python -m py_compile dual-subtitle-burner.py sub-merger.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b89a2f7c8332a0118df09268ca9d